### PR TITLE
Fix gesture recogniser testing in SPM

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -15,7 +15,7 @@ let package = Package(
     ],
     dependencies: [],
     targets: [
-        .target(name: "DJATesting_ObjC", path: "Sources/DJATesting/ObjC"),
+        .target(name: "DJATesting_ObjC", path: "Sources/DJATesting/ObjC", publicHeadersPath: "."),
         .target(name: "DJATesting", dependencies: ["DJATesting_ObjC"], exclude: ["ObjC"])
     ],
     swiftLanguageVersions: [.v5]

--- a/Sources/DJATesting/UIKit/Exports.swift
+++ b/Sources/DJATesting/UIKit/Exports.swift
@@ -1,0 +1,1 @@
+@_exported import DJATesting_ObjC


### PR DESCRIPTION
Ensures that the gesture recogniser code is exported to `DJATesting` when used via SPM - otherwise you get a symbol not found error.