### PR TITLE
Optional Transition Coordinator

### DIFF
--- a/DJATesting.xcodeproj/project.pbxproj
+++ b/DJATesting.xcodeproj/project.pbxproj
@@ -450,7 +450,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.7.0;
+				MARKETING_VERSION = 2.8.0;
 				MODULE_VERIFIER_SUPPORTED_LANGUAGES = "objective-c objective-c++";
 				MODULE_VERIFIER_SUPPORTED_LANGUAGE_STANDARDS = "gnu11 gnu++14";
 				PRODUCT_BUNDLE_IDENTIFIER = com.darjeeling.DJATesting;
@@ -488,7 +488,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.7.0;
+				MARKETING_VERSION = 2.8.0;
 				MODULE_VERIFIER_SUPPORTED_LANGUAGES = "objective-c objective-c++";
 				MODULE_VERIFIER_SUPPORTED_LANGUAGE_STANDARDS = "gnu11 gnu++14";
 				PRODUCT_BUNDLE_IDENTIFIER = com.darjeeling.DJATesting;

--- a/Sources/DJATesting/UIKit/Mocks/MockNavigationController.swift
+++ b/Sources/DJATesting/UIKit/Mocks/MockNavigationController.swift
@@ -180,11 +180,16 @@ public class MockNavigationController: UINavigationController {
     }
     
     /// The mock transition coordinator returned by the receiver's
-    /// `transitionCoordinator` property.
+    /// ``transitionCoordinator`` property when
+    /// ``usesMockTransitionCoordinator`` is `true`.
     public let mockTransitionCoordinator = MockTransitionCoordinator()
     
+    /// A `Boolean` value determining whether ``mockTransitionCoordinator`` will
+    /// be returned from ``transitionCoordinator`` or not. Defaults to `true`.
+    public var usesMockTransitionCoordinator = true
+    
     public override var transitionCoordinator: UIViewControllerTransitionCoordinator? {
-        return mockTransitionCoordinator
+        return usesMockTransitionCoordinator ? mockTransitionCoordinator : super.transitionCoordinator
     }
 }
 

--- a/Sources/DJATesting/UIKit/Mocks/MockSplitViewController.swift
+++ b/Sources/DJATesting/UIKit/Mocks/MockSplitViewController.swift
@@ -163,11 +163,16 @@ public class MockSplitViewController: UISplitViewController {
     }
     
     /// The mock transition coordinator returned by the receiver's
-    /// `transitionCoordinator` property.
+    /// ``transitionCoordinator`` property when
+    /// ``usesMockTransitionCoordinator`` is `true`.
     public let mockTransitionCoordinator = MockTransitionCoordinator()
     
+    /// A `Boolean` value determining whether ``mockTransitionCoordinator`` will
+    /// be returned from ``transitionCoordinator`` or not. Defaults to `true`.
+    public var usesMockTransitionCoordinator = true
+    
     public override var transitionCoordinator: UIViewControllerTransitionCoordinator? {
-        return mockTransitionCoordinator
+        return usesMockTransitionCoordinator ? mockTransitionCoordinator : super.transitionCoordinator
     }
 }
 

--- a/Sources/DJATesting/UIKit/Mocks/MockTabBarController.swift
+++ b/Sources/DJATesting/UIKit/Mocks/MockTabBarController.swift
@@ -122,11 +122,16 @@ public class MockTabBarController: UITabBarController {
     }
     
     /// The mock transition coordinator returned by the receiver's
-    /// `transitionCoordinator` property.
+    /// ``transitionCoordinator`` property when
+    /// ``usesMockTransitionCoordinator`` is `true`.
     public let mockTransitionCoordinator = MockTransitionCoordinator()
     
+    /// A `Boolean` value determining whether ``mockTransitionCoordinator`` will
+    /// be returned from ``transitionCoordinator`` or not. Defaults to `true`.
+    public var usesMockTransitionCoordinator = true
+    
     public override var transitionCoordinator: UIViewControllerTransitionCoordinator? {
-        return mockTransitionCoordinator
+        return usesMockTransitionCoordinator ? mockTransitionCoordinator : super.transitionCoordinator
     }
 }
 


### PR DESCRIPTION
Adds:
* `-[MockNavigationController usesMockTransitionCoordinator]`
* `-[MockSplitViewController usesMockTransitionCoordinator]`
* `-[MockTabBarController usesMockTransitionCoordinator]`